### PR TITLE
🐛 Виправлено відправку щоденного звіту: час >= запланованого

### DIFF
--- a/web/app/api/cron/reports-daily/route.ts
+++ b/web/app/api/cron/reports-daily/route.ts
@@ -132,7 +132,13 @@ export async function POST(req: NextRequest) {
     const alreadySent =
       lastRun?.kyivDay === now.kyivDay && lastRun?.schedule === schedule.label && lastRun.ok;
 
-    if (!force && now.label !== schedule.label) {
+    // Порівнюємо час у хвилинах, щоб звіт відправлявся коли час >= запланованого,
+    // а не лише при точному збігу (cron запускається кожні 5 хв, тому точний збіг малоймовірний).
+    const nowMinutes = now.hours * 60 + now.minutes;
+    const scheduleMinutes = schedule.hours * 60 + schedule.minutes;
+    const timeHasCome = nowMinutes >= scheduleMinutes;
+
+    if (!force && !timeHasCome) {
       const payload = {
         kyivDay: now.kyivDay,
         schedule: schedule.label,
@@ -144,10 +150,12 @@ export async function POST(req: NextRequest) {
         recipientCount: 0,
         via: "skip:not-time",
       } satisfies DailyReportLastRun;
-      console.log("[cron/reports-daily] Пропуск — не час:", {
+      console.log("[cron/reports-daily] Пропуск — ще не час:", {
         schedule: schedule.label,
         now: now.label,
         kyivDay: now.kyivDay,
+        nowMinutes,
+        scheduleMinutes,
       });
       await appendCronLog({ ...payload, reason: "not-time" });
       return NextResponse.json({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема
Щоденний звіт не відправлявся, тому що код перевіряв **точний збіг** поточного часу з запланованим (13:30 Kyiv).

Оскільки cron запускається кожні 5 хвилин, шанси потрапити точно на 13:30 — малі. Тому звіт постійно пропускався з причиною "not-time".

## Рішення
Змінено логіку перевірки часу:
- **Було:** `if (now.label !== schedule.label)` — точний збіг часу (13:30 === 13:30)
- **Стало:** `if (nowMinutes < scheduleMinutes)` — поточний час >= запланованого

Тепер звіт відправиться при першому запуску cron після запланованого часу (13:30, 13:35, 13:40 тощо), якщо ще не відправлявся сьогодні.

## Що перевірено
- ✅ Логіка перевірки часу в хвилинах
- ✅ Збережено перевірку "вже відправлено сьогодні"
- ✅ Додано логування nowMinutes/scheduleMinutes для діагностики

## Тестування
Після деплою:
1. Дочекатися наступного запуску cron (кожні 5 хв)
2. Якщо поточний час Kyiv >= 13:30, звіт має відправитися
3. Перевірити KV: `reports:daily:last-run` та `reports:daily:cron:log`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f41c3-9dbb-7ca8-b8a5-a47d1b59cdf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f41c3-9dbb-7ca8-b8a5-a47d1b59cdf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

